### PR TITLE
fixes-#5-httplib-is-failing-using-yum: adding some extra common files…

### DIFF
--- a/provisioning/roles/common/tasks/main.yml
+++ b/provisioning/roles/common/tasks/main.yml
@@ -1,9 +1,4 @@
 ---
-- name: Check if os packages are installed
-  stat:
-    path: /usr/bin/easy_install
-  register: os_packages
-
 - name: Check if pip is installed
   stat:
     path: /bin/pip
@@ -12,6 +7,14 @@
 - name: Install os packages
   yum: name={{item}} state=present
   with_items:
+  - zlib-devel
+  - gcc
+  - make
+  - git
+  - autoconf
+  - autogen
+  - automake
+  - pkgconfig
   - unzip
   - bc
   - net-tools
@@ -19,7 +22,6 @@
   - vim
   - python-devel
   - python-setuptools
-  when: os_packages.stat.exists == False
 
 
 - name: Download pip.

--- a/provisioning/roles/jenkins/tasks/main.yml
+++ b/provisioning/roles/jenkins/tasks/main.yml
@@ -20,7 +20,7 @@
 
 - name: Install httplib2
   pip: name=httplib2
-  when: os_packages.stat.exists == False
+  when: httplib2.stat.exists == False
 
 
 - name: Directories are present
@@ -64,6 +64,7 @@
     volumes: /data/jenkins:/var/jenkins_home
     state: started
   tags: [jenkins]
+  register: running_container
 
 - name: Reload
   uri:
@@ -72,3 +73,4 @@
     status_code=302
   ignore_errors: yes
   tags: [jenkins]
+  failed_when: running_container.rc == 1


### PR DESCRIPTION
fixes-#5-httplib-is-failing-using-yum: adding some extra common files to be downloaded that will be used when adding other roles as well as moving httplib away from jenkins role and yum provisioner.
referencing pull #6 -> needs rebasing before merge
