### PR TITLE
fixes-#13-add-bind-2375-port-to-docker-engine: removed redundant file…

### DIFF
--- a/provisioning/roles/docker/files/override.conf
+++ b/provisioning/roles/docker/files/override.conf
@@ -1,4 +1,0 @@
-[Service]
-EnvironmentFile=-/etc/sysconfig/docker
-ExecStart=
-ExecStart=/usr/bin/docker daemon -H fd:// $DOCKER_OPTS

--- a/provisioning/roles/docker/tasks/install.yml
+++ b/provisioning/roles/docker/tasks/install.yml
@@ -23,9 +23,16 @@
 
 - name: install updates
   yum: update_cache=yes name=docker-engine state=latest disablerepo=extras,extras-source
+  when: docker.stat.exists == False
+  ignore_errors: yes
+
+- name: Add docker.service
+  template:
+    src: docker.service.j2
+    dest: /usr/lib/systemd/system/docker.service
+    mode: 0644
+    owner: root
   notify:
     - reload systemd
     - start docker
-  when: docker.stat.exists == False
-  changed_when: no
   ignore_errors: yes

--- a/provisioning/roles/docker/templates/docker.service.j2
+++ b/provisioning/roles/docker/templates/docker.service.j2
@@ -1,0 +1,22 @@
+[Unit]
+Description=Docker Application Container Engine
+Documentation=https://docs.docker.com
+After=network.target docker.socket
+Requires=docker.socket
+
+[Service]
+Type=notify
+# the default is not to use systemd for cgroups because the delegate issues still
+# exists and systemd currently does not support the cgroup feature set required
+# for containers run by docker
+ExecStart=/usr/bin/docker daemon -H fd:// -H 0.0.0.0:2375
+MountFlags=slave
+LimitNOFILE=1048576
+LimitNPROC=1048576
+LimitCORE=infinity
+TimeoutStartSec=0
+# set delegate yes so that systemd does not reset the cgroups of docker containers
+Delegate=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/provisioning/roles/docker/templates/sysconfig.j2
+++ b/provisioning/roles/docker/templates/sysconfig.j2
@@ -1,5 +1,0 @@
-{% if ansible_distribution_major_version == "7" %}
-DOCKER_OPTS="{{ docker_opts }}"
-{% elif ansible_distribution_major_version == "6" %}
-other_args="{{ docker_opts }}"
-{% endif %}


### PR DESCRIPTION
fixes-#13-add-bind-2375-port-to-docker-engine: removed redundant files like override.conf and sysconfig file and added a docker.service systemctl file
